### PR TITLE
Adding support for focus()

### DIFF
--- a/projects/klippa/ngx-enhancy-forms/package.json
+++ b/projects/klippa/ngx-enhancy-forms/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@klippa/ngx-enhancy-forms",
-	"version": "11.4.0",
+	"version": "11.5.0",
 	"publishConfig": {
 		"access": "public"
 	},

--- a/projects/klippa/ngx-enhancy-forms/src/lib/elements/checkbox/checkbox.component.html
+++ b/projects/klippa/ngx-enhancy-forms/src/lib/elements/checkbox/checkbox.component.html
@@ -4,6 +4,7 @@
 			[(ngModel)]="innerValue"
 			(change)="setInnerValueAndNotify(innerValue); touch()"
 			[disabled]="disabled"
+			#nativeInputRef
 		/>
     <div class="checkboxVisual">
       <svg *ngIf="innerValue === true" version="1.1" viewBox="0 0 4.2333 4.2333" xmlns="http://www.w3.org/2000/svg">

--- a/projects/klippa/ngx-enhancy-forms/src/lib/elements/email/email-input.component.html
+++ b/projects/klippa/ngx-enhancy-forms/src/lib/elements/email/email-input.component.html
@@ -6,4 +6,5 @@
 	[placeholder]="placeholder"
 	(blur)="touch()"
 	[disabled]="disabled"
+	#nativeInputRef
 />

--- a/projects/klippa/ngx-enhancy-forms/src/lib/elements/file-input/file-input.component.html
+++ b/projects/klippa/ngx-enhancy-forms/src/lib/elements/file-input/file-input.component.html
@@ -5,7 +5,7 @@
 		</klp-form-button>
 		<input
 			type="file"
-			#fileInput
+			#nativeInputRef
 			(change)="onChange($event.target.files)"
 			[multiple]="multiple"
 			[disabled]="disabled"

--- a/projects/klippa/ngx-enhancy-forms/src/lib/elements/file-input/file-input.component.ts
+++ b/projects/klippa/ngx-enhancy-forms/src/lib/elements/file-input/file-input.component.ts
@@ -15,7 +15,7 @@ export class FileInputComponent extends MultipleValueAccessorBase<File> {
 	@Input() clearable = false;
 	@Input() onlyShowUploadButton = false;
 	@Input() useFullParentSize = false;
-	@ViewChild('fileInput') fileInputEl: ElementRef<HTMLInputElement>;
+	@ViewChild('nativeInputRef') nativeInputRef: ElementRef<HTMLInputElement>;
 
 	public onChange(files: FileList): void {
 		const result = [];
@@ -24,7 +24,7 @@ export class FileInputComponent extends MultipleValueAccessorBase<File> {
 		}
 		this.setInnerValueAndNotify(result);
 		// to make sure we can select the same file again
-		this.fileInputEl.nativeElement.value = null;
+		this.nativeInputRef.nativeElement.value = null;
 	}
 
 	public getFileNames(): string {
@@ -53,6 +53,6 @@ export class FileInputComponent extends MultipleValueAccessorBase<File> {
 	}
 
 	public uploadFileClicked(): void {
-		this.fileInputEl.nativeElement.click();
+		this.nativeInputRef.nativeElement.click();
 	}
 }

--- a/projects/klippa/ngx-enhancy-forms/src/lib/elements/hour-minute-input/hour-minute-input.component.html
+++ b/projects/klippa/ngx-enhancy-forms/src/lib/elements/hour-minute-input/hour-minute-input.component.html
@@ -1,5 +1,5 @@
 <div class="componentContainer" [ngClass]="{disabled: disabled}">
-	<input class="hourInput" maxlength="4" [placeholder]="placeholders[0]" [disabled]="disabled" [(ngModel)]="hours" (blur)="formatHours(); formatTime(); touchHours(); notifyNewTime()" (ngModelChange)="notifyNewTime()">
+	<input class="hourInput" maxlength="4" [placeholder]="placeholders[0]" [disabled]="disabled" [(ngModel)]="hours" (blur)="formatHours(); formatTime(); touchHours(); notifyNewTime()" (ngModelChange)="notifyNewTime()" #nativeInputRef>
 	<div class="divider">:</div>
 	<input maxlength="2" [placeholder]="placeholders[1]" [disabled]="disabled" [(ngModel)]="minutes" (blur)="formatMinutes(); formatTime(); touchMinutes(); notifyNewTime()" (ngModelChange)="notifyNewTime()">
 </div>

--- a/projects/klippa/ngx-enhancy-forms/src/lib/elements/number-input/number-input.component.html
+++ b/projects/klippa/ngx-enhancy-forms/src/lib/elements/number-input/number-input.component.html
@@ -6,4 +6,5 @@
 	[placeholder]="placeholder ? placeholder : ''"
 	[ngClass]="{showErrors: isInErrorState()}"
 	[disabled]="disabled"
+	#nativeInputRef
 />

--- a/projects/klippa/ngx-enhancy-forms/src/lib/elements/password-field/password-field.component.html
+++ b/projects/klippa/ngx-enhancy-forms/src/lib/elements/password-field/password-field.component.html
@@ -7,4 +7,5 @@
 	[placeholder]="placeholder"
 	(blur)="touch()"
 	[disabled]="disabled"
+	#nativeInputRef
 />

--- a/projects/klippa/ngx-enhancy-forms/src/lib/elements/select/select.component.ts
+++ b/projects/klippa/ngx-enhancy-forms/src/lib/elements/select/select.component.ts
@@ -119,4 +119,8 @@ export class SelectComponent extends ValueAccessorBase<string | string[]> implem
 			}
 		});
 	}
+
+	public focus = (): void => {
+		this.ngSelect.focus();
+	}
 }

--- a/projects/klippa/ngx-enhancy-forms/src/lib/elements/text-input/text-input.component.html
+++ b/projects/klippa/ngx-enhancy-forms/src/lib/elements/text-input/text-input.component.html
@@ -10,6 +10,7 @@
 		[placeholder]="placeholder ? placeholder : ''"
 		(blur)="touch(); onBlur.emit()"
 		[disabled]='disabled'
+		#nativeInputRef
 	/>
 	<div class="clearIcon" *ngIf="clearable && innerValue?.length > 0" (click)="resetToNull()">×</div>
 </div>

--- a/projects/klippa/ngx-enhancy-forms/src/lib/elements/toggle/toggle.component.html
+++ b/projects/klippa/ngx-enhancy-forms/src/lib/elements/toggle/toggle.component.html
@@ -4,6 +4,7 @@
 		(input)="setInnerValueAndNotify($event.target.checked); touch()"
 		[disabled]="disabled"
 		[ngClass]="{showErrors: isInErrorState()}"
+	 #nativeInputRef
 	/>
 	<div class="toggleVisual"></div>
 </div>

--- a/projects/klippa/ngx-enhancy-forms/src/lib/elements/value-accessor-base/value-accessor-base.component.ts
+++ b/projects/klippa/ngx-enhancy-forms/src/lib/elements/value-accessor-base/value-accessor-base.component.ts
@@ -1,5 +1,5 @@
 import {ControlContainer, ControlValueAccessor, UntypedFormControl} from '@angular/forms';
-import {Component, EventEmitter, Host, Input, OnDestroy, OnInit, Optional, Output} from '@angular/core';
+import {Component, ElementRef, EventEmitter, Host, Input, OnDestroy, OnInit, Optional, Output, ViewChild} from '@angular/core';
 import {FormElementComponent} from '../../form/form-element/form-element.component';
 import {isNullOrUndefined, isValueSet, stringIsSetAndFilled} from '../../util/values';
 import { arrayIsSetAndFilled } from '../../util/arrays';
@@ -32,6 +32,7 @@ export class ValueAccessorBase<T> implements ControlValueAccessor, OnInit, OnDes
 	@Input() public formControlName: string = null;
 	@Input() public formControl: UntypedFormControl = null;
 	@Output() public onTouch = new EventEmitter<void>();
+	@ViewChild('nativeInputRef') nativeInputRef: ElementRef;
 
 	private attachedFormControl: UntypedFormControl;
 	private validators: Array<string> = [];
@@ -131,5 +132,13 @@ export class ValueAccessorBase<T> implements ControlValueAccessor, OnInit, OnDes
 			return this.validators.includes(validatorName);
 		}
 		return false;
+	}
+
+	public focus = (): void => {
+		if (isValueSet(this.nativeInputRef?.nativeElement)){
+			this.nativeInputRef?.nativeElement?.focus();
+		}else {
+			throw new Error('the focus() method is not implemented in this element!');
+		}
 	}
 }


### PR DESCRIPTION
Adding [ElementRef](https://angular.io/api/core/ElementRef) to all the input fields. This allows the valueBaseAccesser to call the `focus()` method on the `NativeElement`. This allows the user of this lib to force a user to focus on a specific enhancy-form element.