### PR TITLE
Form should inherit height from parent

### DIFF
--- a/projects/klippa/ngx-enhancy-forms/package.json
+++ b/projects/klippa/ngx-enhancy-forms/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@klippa/ngx-enhancy-forms",
-	"version": "11.4.0",
+	"version": "11.5.1",
 	"publishConfig": {
 		"access": "public"
 	},

--- a/projects/klippa/ngx-enhancy-forms/src/lib/form/form.component.scss
+++ b/projects/klippa/ngx-enhancy-forms/src/lib/form/form.component.scss
@@ -3,4 +3,7 @@
 	&.row {
 		display: flex;
 	}
+	form {
+		height: inherit;
+	}
 }


### PR DESCRIPTION
The `form` element cannot be styled in Klippa, but it needs to have max height when setting the `app-card-container` to max height, by setting `height: inherit` it will only use the height of the parent when that is explicitly set:

![image](https://user-images.githubusercontent.com/779921/209833133-eec119df-a336-4bd2-8459-a431c8054aea.png)
