### PR TITLE
Remove form element host di decorator

### DIFF
--- a/projects/demo/src/app/app.component.html
+++ b/projects/demo/src/app/app.component.html
@@ -1,5 +1,7 @@
 <klp-form [formGroup]="myForm">
 	<div style="height: 500px; overflow: auto">
+		<app-deep-input>
+		</app-deep-input>
 		<klp-form-element caption="Name" spaceDistribution="34-66">
 			<klp-form-text-input formControlName="name" [hasBorderLeft]="false" [hasBorderRight]="false">
 			</klp-form-text-input>

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -23,6 +23,7 @@ export class AppComponent {
 	isChecked: boolean = undefined;
 
 	public myForm = this.fb.group({
+		deepInput: ['', Validators.required],
 		name: [''],
 		emails: [''],
 		disabledButRendered: ['disabledButRendered'],

--- a/projects/demo/src/app/app.module.ts
+++ b/projects/demo/src/app/app.module.ts
@@ -6,6 +6,7 @@ import {AppComponent} from './app.component';
 import {NgxEnhancyFormsModule} from '@klippa/ngx-enhancy-forms';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {SubFormExampleComponent} from './subForm/sub-form-example.component';
+import DeepInputComponent from './deep-input/deep-input.component';
 
 @NgModule({
 	imports: [
@@ -18,6 +19,7 @@ import {SubFormExampleComponent} from './subForm/sub-form-example.component';
 	declarations: [
 		AppComponent,
 		SubFormExampleComponent,
+		DeepInputComponent,
 	],
 	providers: [],
 	bootstrap: [AppComponent]

--- a/projects/demo/src/app/deep-input/deep-input.component.html
+++ b/projects/demo/src/app/deep-input/deep-input.component.html
@@ -1,0 +1,6 @@
+<ng-container [formGroup]="fg.form">
+	<klp-form-element caption="deep input">
+		<klp-form-text-input formControlName="deepInput">
+		</klp-form-text-input>
+	</klp-form-element>
+</ng-container>

--- a/projects/demo/src/app/deep-input/deep-input.component.ts
+++ b/projects/demo/src/app/deep-input/deep-input.component.ts
@@ -1,0 +1,10 @@
+import { Component, inject } from "@angular/core";
+import { FormGroupDirective } from "@angular/forms";
+
+@Component({
+	selector: 'app-deep-input',
+	templateUrl: './deep-input.component.html',
+})
+export default class DeepInputComponent {
+	protected fg = inject(FormGroupDirective);
+}

--- a/projects/klippa/ngx-enhancy-forms/package.json
+++ b/projects/klippa/ngx-enhancy-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klippa/ngx-enhancy-forms",
-  "version": "14.6.2",
+  "version": "14.7.0",
   "publishConfig": {
     "access": "public"
   },

--- a/projects/klippa/ngx-enhancy-forms/src/lib/form/form-element/form-element.component.ts
+++ b/projects/klippa/ngx-enhancy-forms/src/lib/form/form-element/form-element.component.ts
@@ -39,10 +39,9 @@ export class FormElementComponent {
 	private input: ValueAccessorBase<any>;
 
 	constructor(
-		@Host() @Optional() private parent: FormComponent,
+		 @Optional() private parent: FormComponent,
 		@Inject(FORM_ERROR_MESSAGES) @Optional() private customMessages: CustomErrorMessages,
-	) {
-	}
+	) {}
 
 	public shouldShowErrorMessages(): boolean {
 		return this.parent?.showErrorMessages !== false;


### PR DESCRIPTION
@wouter-willems 

The most important thing here is removing the host DI decorator from the form-element.

The yarn stuff is because DH now uses yarn v3, this is the only way to stop my version of yarn from upgrading enhancy-forms to v 3. Tbh it's probably a good idea to be pinning the yarn version like this as it prevents "but it worked with my version of yarn" issues.

The devenv stuff is because I no-longer have any development tools installed globally, it's a pain in the ass switching between branches with old angular versions or different go versions with globally installed tooling.
Devenv's are normally committed and are not NixOS specific. Anyone on any OS can use devenv and have all the programs necessary to develop for this project installed with the correct versions automatically.
You can read more about it here: https://devenv.sh/
I can git ignore the devenv, but then it becomes very inefficient to develop on this repo.