### PR TITLE
Implement percentage widths with just flex

### DIFF
--- a/projects/klippa/ngx-enhancy-forms/src/lib/form/form-element/form-element.component.scss
+++ b/projects/klippa/ngx-enhancy-forms/src/lib/form/form-element/form-element.component.scss
@@ -37,12 +37,12 @@
 	flex: 0 0 auto;
 	padding-right: $spacing-medium;
 	&.percentageSpacing {
-		flex: 0 0 40%;
+		flex: 40;
 		&.d30-70 {
-			flex-basis: 30%;
+			flex: 30;
 		}
 		&.d34-66 {
-			flex-basis: 34%;
+			flex: 34;
 		}
 	}
 	color: $default-dark;
@@ -67,12 +67,12 @@
 .inputContainer {
 	flex: 1;
 	&.percentageSpacing {
-		flex: 0 0 60%;
+		flex: 60;
 		&.d30-70 {
-			flex-basis: 70%;
+			flex: 70;
 		}
 		&.d34-66 {
-			flex-basis: 66%;
+			flex: 66;
 		}
 	}
 }


### PR DESCRIPTION
Implement percentage widths with just flex and not flex-basis to prevent container overflow when using gap.

When you use flex-basis with percentages, it does not take the gap width into account, causing the element to overflow the container. If you just use `flex: {number}`, this does not happen.

Before:
![image](https://github.com/klippa-app/ngx-enhancy-forms/assets/1312921/c4c05e26-85c6-4f38-84f7-e083c963d6f5)

![image](https://github.com/klippa-app/ngx-enhancy-forms/assets/1312921/550b4cf0-5648-486f-8465-4feedcc937ab)
