### PR TITLE
accounted for caption padding and changed error messaging on Required…

### DIFF
--- a/projects/demo/src/app/demo/demo.component.ts
+++ b/projects/demo/src/app/demo/demo.component.ts
@@ -75,7 +75,7 @@ export class DemoComponent {
 				return Promise.resolve({async: 'something'});
 			}
 		],
-		emails: [''],
+		emails: ['', Validators.required],
 		disabledButRendered: ['disabledButRendered'],
 		unrendered: ['unrendered'],
 		yesno: false,

--- a/projects/klippa/ngx-enhancy-forms/package.json
+++ b/projects/klippa/ngx-enhancy-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klippa/ngx-enhancy-forms",
-  "version": "14.10.0",
+  "version": "14.10.1",
   "publishConfig": {
     "access": "public"
   },

--- a/projects/klippa/ngx-enhancy-forms/src/lib/form/form-element/form-element.component.scss
+++ b/projects/klippa/ngx-enhancy-forms/src/lib/form/form-element/form-element.component.scss
@@ -144,12 +144,12 @@ $triangleSize: 12px;
 .errorContainer {
 	color: $default-warning;
 	&.hasCaption {
-		margin-left: 40%;
+		margin-left: calc(40% + $spacing-medium);
 		&.d30-70 {
-			margin-left: 30%;
+			margin-left: calc(30% + $spacing-medium);
 		}
 		&.d34-66 {
-			margin-left: 34%;
+			margin-left: calc(34% + $spacing-medium);
 		}
 	}
 }

--- a/projects/klippa/ngx-enhancy-forms/src/lib/form/form-element/form-element.component.ts
+++ b/projects/klippa/ngx-enhancy-forms/src/lib/form/form-element/form-element.component.ts
@@ -1,16 +1,17 @@
-import {Component, Directive, ElementRef, Host, Inject, InjectionToken, Input, OnInit, Optional, ViewChild} from '@angular/core';
-import {AbstractControl, FormArray, UntypedFormControl, FormGroup} from '@angular/forms';
-import {FormComponent} from '../form.component';
+import {Component, ElementRef, Inject, InjectionToken, Input, Optional, ViewChild} from '@angular/core';
+import {AbstractControl, UntypedFormControl} from '@angular/forms';
+import {ValueAccessorBase} from '../../elements/value-accessor-base/value-accessor-base.component';
 import {CustomErrorMessages, FormErrorMessages} from '../../types';
-import { ValueAccessorBase } from '../../elements/value-accessor-base/value-accessor-base.component';
-import { isValueSet } from '../../util/values';
+import {isValueSet} from '../../util/values';
+import {FormComponent} from '../form.component';
+
 
 export const FORM_ERROR_MESSAGES = new InjectionToken<CustomErrorMessages>('form.error.messages');
 
 export const DEFAULT_ERROR_MESSAGES: FormErrorMessages = {
 	min: 'Use a number larger than %min%',
 	max: 'Use a number smaller than %max%',
-	required: 'This field is required',
+	required: 'Required',
 	email: 'Use a valid email address',
 	minLength: 'Has to be longer than %minLength% character(s)',
 	maxLength: 'Has to be shorter than %maxLength% character(s)',


### PR DESCRIPTION
Issue description: 
Caption padding on error container is not accounted for when for example we have a form field that is required. 

Image of issue: 
![Screenshot 2023-12-05 at 11 51 18](https://github.com/klippa-app/ngx-enhancy-forms/assets/63120475/1b9be309-fd6a-47af-bca0-3cfbf50785c6)

With fix: 

![Screenshot 2023-12-05 at 12 05 04](https://github.com/klippa-app/ngx-enhancy-forms/assets/63120475/13b5f7ba-12a8-4eb7-95e4-ee9fdba8402b)

