### PR TITLE
Fixed dot not working in number input

### DIFF
--- a/projects/klippa/ngx-enhancy-forms/package.json
+++ b/projects/klippa/ngx-enhancy-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klippa/ngx-enhancy-forms",
-  "version": "20.1.3",
+  "version": "20.1.4",
   "publishConfig": {
     "access": "public"
   },

--- a/projects/klippa/ngx-enhancy-forms/src/lib/elements/number-input/number-input.component.html
+++ b/projects/klippa/ngx-enhancy-forms/src/lib/elements/number-input/number-input.component.html
@@ -13,8 +13,8 @@
 	<input
 		type="number"
 		class="form-control"
-		[(ngModel)]="innerValue"
-		(input)="setInnerValueAndNotify($event.target.value)"
+		[ngModel]="innerValue"
+		(ngModelChange)="setInnerValueAndNotify($event)"
 		[placeholder]="placeholder ? placeholder : ''"
 		[ngClass]="{showErrors: isInErrorState(), disabled: disabled}"
 		[disabled]="disabled"


### PR DESCRIPTION
Basically the (input) emitter from <input> would return null when using a dot AFTER a number (due to locales I believe). This PR changed it so it listens to the output of ngModel instead, which does not have this limitation